### PR TITLE
Py2support

### DIFF
--- a/scorer/app.py
+++ b/scorer/app.py
@@ -11,6 +11,12 @@ NO_LIVE_MATCHES = "No Match in progress"
 SLEEP_INTERVAL = 15 
 
 def main():
+    try:
+        input = raw_input
+        logging.debug("Python 2 : Using raw_input()")
+    except NameError:
+        logging.debug("Python 3 : Using input()")
+        pass
     while True:
         logging.debug("Getting the xml and matches list")
         xml, matches = fs.findMatchesAvailable()
@@ -22,7 +28,7 @@ def main():
             print (index, ".", game)
         print (index+1, ". Quit ")
         try:
-            matchChoice = str(input("Enter your choice: ")).strip()
+            matchChoice = input("Enter your choice: ").strip()
         except KeyboardInterrupt:
                 exitApp()   
         while True:


### PR DESCRIPTION
Input function Bug Fix for python 2 & 3 compatibility : input() now works fine with both python2 and python3
    
The implementation of input() is different in python 2 and 3. This fix checks whether user runs python2 or 3 and overrides input method accordingly. This fixes a previous bug where the program would fail if the user provided any non-digit input while using the app on python2